### PR TITLE
Add image for self-hosted github runner

### DIFF
--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -4,19 +4,37 @@ FROM phoenixrtos/build:latest
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-        python3 \
+        python3-dev \
+        python3-venv \
         python3-pip \
-	opensbi \
-	qemu-system-i386 \
-	qemu-system-misc \
-	qemu-utils \
-	u-boot-qemu \
+        opensbi \
+        qemu-system-i386 \
+        qemu-system-misc \
+        qemu-utils \
+        u-boot-qemu \
     && rm -rf /var/lib/apt/lists/*
+
+# prepare virtual env
+RUN python3 -m venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
 
 # get python requirements
 RUN pip3 install --no-cache-dir \
-	pyserial \
-	pyyaml \
-	pexpect
+    pyserial \
+    pyyaml \
+    pexpect \
+    RPi.GPIO
+
+# install hostutils
+RUN git clone --recursive https://github.com/phoenix-rtos/phoenix-rtos-project.git && \
+    cd phoenix-rtos-project && \
+    TARGET=host-pc make -C phoenix-rtos-hostutils -f Makefile.old all && \
+    mkdir -p /opt/phoenix/utils && \
+    (cd _build/host-pc/prog.stripped && cp phoenixd psu psdisk /opt/phoenix/utils) && \
+    cd .. && rm -rf phoenix-rtos-project && \
+    chmod -R a+rwX /opt/phoenix/utils
+
+ENV PATH="/opt/phoenix/utils:${PATH}"
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/gh-runner/Dockerfile
+++ b/gh-runner/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:20.04
+
+ARG GH_RUNNER_VERSION=2.278.0
+ARG GH_PLATFORM=arm
+
+ENV RUNNER_ALLOW_RUNASROOT=true
+
+WORKDIR /actions-runner
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        libhidapi-dev \
+        python3-dev \
+        python3-pip \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# install github actions runner
+RUN curl -L -O https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-${GH_PLATFORM}-${GH_RUNNER_VERSION}.tar.gz \
+    && tar -xzf ./actions-runner-linux-${GH_PLATFORM}-${GH_RUNNER_VERSION}.tar.gz \
+    && rm -rf ./actions-runner-linux-${GH_PLATFORM}-${GH_RUNNER_VERSION}.tar.gz \
+    && DEBIAN_FRONTEND=noninteractive ./bin/installdependencies.sh \
+    && rm -rf /var/lib/apt/lists/*
+
+# get phoenix-rtos host utils
+COPY --from=phoenixrtos/devel /opt/phoenix/utils /opt/phoenix/utils
+ENV PATH="/opt/phoenix/utils:${PATH}"
+
+# get virtual env for runner
+COPY --from=phoenixrtos/devel /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# install requests for entry.py
+RUN pip3 install --no-cache-dir \
+    requests
+
+COPY entry.py .
+
+ENTRYPOINT ["python3", "entry.py"]
+CMD ["/actions-runner/bin/runsvc.sh"]

--- a/gh-runner/entry.py
+++ b/gh-runner/entry.py
@@ -1,0 +1,79 @@
+import os
+import requests
+import sys
+import subprocess
+
+
+def resolve_api_url():
+    url = os.getenv('GITHUB_REPO_URL') or os.getenv('GITHUB_ORG_URL')
+    if not url:
+        print('Need GITHUB_REPO_URL or GITHUB_ORG_URL!')
+        sys.exit(1)
+
+    scope = 'repos' if os.getenv('GITHUB_REPO_URL') else 'orgs'
+    name = url.lstrip('https://github.com/')
+
+    return f'https://api.github.com/{scope}/{name}'
+
+
+def get_runner_token():
+    token = os.getenv('GITHUB_RUNNER_TOKEN')
+    if token:
+        return token
+
+    api_token = os.getenv('GITHUB_API_TOKEN')
+    if not api_token:
+        print('Need GITHUB_API_TOKEN or GITHUB_RUNNER_TOKEN!')
+        sys.exit(1)
+
+    resp = requests.post(
+        f'{API_URL}/actions/runners/registration-token',
+        headers={
+            'Accept': 'application/vnd.github.v3+json',
+            'Authorization': f'token {api_token}',
+        }
+    )
+
+    if resp.ok:
+        json = resp.json()
+        return json['token']
+    else:
+        print("Cannot get token from API!")
+        sys.exit(1)
+
+
+def configure_runner():
+    token = get_runner_token()
+    label = os.getenv('GITHUB_RUNNER_LABEL')
+    name = os.getenv('GITHUB_RUNNER_NAME')
+    replace = os.getenv('GITHUB_RUNNER_REPLACE')
+    url = os.getenv('GITHUB_REPO_URL') or os.getenv('GITHUB_ORG_URL')
+    work_dir = "_work"
+
+    exe = ['./config.sh',
+           '--unattended',
+           '--token', token,
+           '--name', name,
+           '--url', url,
+           '--work', work_dir]
+
+    if label:
+        exe.extend(['--labels', label])
+
+    if replace:
+        exe.append('--replace')
+
+    proc = subprocess.run(exe)
+
+    if proc.returncode != 0:
+        print(f'{" ".join(exe)} failed!')
+        sys.exit(1)
+
+
+API_URL = resolve_api_url()
+
+if not os.path.isfile('.runner'):
+    configure_runner()
+
+if len(sys.argv) > 1:
+    os.execv(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
ARM v7 is more or less problematic in building.  Here are some remarks:
1. Building image fails on `wget` because of invalid cert paths. Setting `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` solves problem.
2. There may be a need to run `multiarch/qemu-user-static` in order to build image on a host. 
```bash
docker run --rm --privileged multiarch/qemu-user-static --reset always -p yes
# change default buildx container
docker buildx create --name multiarch --driver docker-container --use
docker buildx inspect --bootstrap
```
3. There may be a need to update `libseccomp` to version >2.4.2 (2.4.4 works well for me) on rpi.
```bash
# execute on raspberry pi
wget http://ftp.pl.debian.org/debian/pool/main/libs/libseccomp/libseccomp2_2.4.4-1~bpo10+1_armhf.deb
sudo apt install ./libseccomp2_2.4.4-1~bpo10+1_armhf.deb
```
Problem no. 1 doesn't occur on ARM64. Also no. 3 should not be needed on ARM64. We are going to use RPi4 so I don't change `build` image.

I built `gh-runner` using following command:
```bash
docker buildx build --platform linux/arm/v7 -t gh-runner .
```

To start github runner on RPi (as a restarting service):
```bash
docker run \
        -e GITHUB_API_TOKEN=${GH_API_TOKEN} \
        -e GITHUB_RUNNER_NAME=my_runner \
        -e GITHUB_RUNNER_LABEL=some_label \
        -e GITHUB_REPO_URL=https://github.com/me/my-repo \
        --device /dev/ttyACM0 \
        --device /dev/ttyUSB0 \
        --device /dev/gpiomem \
        --device /dev/hidraw0 \
        --device /dev/hidraw1 \
        --restart always \
        gh-runner
```