### PR TITLE
gh-runner: add uhubctl for rpi ports control in self-hosted runners

### DIFF
--- a/gh-runner/Dockerfile
+++ b/gh-runner/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         xz-utils \
+        uhubctl \
     && rm -rf /var/lib/apt/lists/*
 
 # install github actions runner


### PR DESCRIPTION
JIRA: CI-69