### PR TITLE
readme: update build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,19 @@ Based on `phoenixrtos/build` - additional development tools added.
 ## Manual build and upload
 
 ```bash
-DOCKER_BUILDKIT=1 docker build . -t phoenixrtos/build
-# building will take about 1 hour - after that test if it builds all TARGETs from phoenix-rtos-project
-docker tag phoenixrtos/build:latest phoenixrtos/build:20201019  # use current date
-docker push phoenixrtos/build
+# additional steps may be needed for building image - check builders using command docker buildx ls
+# run container with all archs
+docker run --rm --privileged multiarch/qemu-user-static -p yes
+# change defualt buildx container
+docker buildx create --name multiarch --driver docker-container --use
+docker buildx inspect --bootstrap
+
+# building will take about approximately 10 hours - after that test if it builds all TARGETs from phoenix-rtos-project
+# use --load flag to load image into docker but it works only for one platform
+# use --push to push multi-platform image into registry use
+docker buildx build --platform linux/arm/v7,linux/amd64 --push -t phoenixrtos/build:latest -f build/Dockerfile .
+
+# additionaly push the image one more time tagged with the current date
+docker buildx build --platform linux/arm/v7,linux/amd64 --push -t phoenixrtos/build:20211126 -f build/Dockerfile .
 ```
 


### PR DESCRIPTION
Buildx can't export multiple architecture image to docker. To test locally the image build it for one platform using `--load`, to push the multiplatform image use `--push`.