### PR TITLE
gh-runner: add libatomic to an image

### DIFF
--- a/gh-runner/Dockerfile
+++ b/gh-runner/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
         python3-pip \
         xz-utils \
         uhubctl \
+        libatomic1 \
     && rm -rf /var/lib/apt/lists/*
 
 # install github actions runner


### PR DESCRIPTION
JIRA: CI-95

During the repository checkout in gh-actions, libatomic shared library started to be missing. Installing the library solves the problem, so I think it should be available in a docker image.