### PR TITLE
devel: provide openocd 0.11 with required tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT VERSION
+* **GCC version: 9.3.0**
+* devel: add openocd 0.11 with required tools
+
 ## 20220926 (latest)
 * **GCC version: 9.3.0**
 * build: add custom entrypoint script for CI use-case (submodule out-of-tree building)

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -4,6 +4,7 @@ ARG DEVEL_XILINX_PLO_VERSION=2021.2
 ARG TARGETPLATFORM
 
 # download python3, qemu and libs to compile Xilinx qemu
+# libusb-1.0 and tclsh needed for appropriate build and using openocd
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
@@ -20,6 +21,8 @@ RUN apt-get update && \
         libpixman-1-dev \
         u-boot-qemu \
         gdb-multiarch \
+        libusb-1.0 \
+        tclsh \
     && rm -rf /var/lib/apt/lists/* \
     && c_rehash # needed for armv7 CA certs to work
 
@@ -43,6 +46,15 @@ RUN git clone --recursive https://github.com/phoenix-rtos/phoenix-rtos-project.g
     (cd _build/host-generic-pc/prog.stripped && cp phoenixd psu psdisk /opt/phoenix/utils) && \
     cd .. && rm -rf phoenix-rtos-project && \
     chmod -R a+rwX /opt/phoenix/utils
+
+# install openocd in 0.11 version
+RUN mkdir -p /etc/udev/rules.d && \
+    git clone https://github.com/openocd-org/openocd.git --branch v0.11.0 && \
+    cd openocd && \
+    ./bootstrap && \
+    ./configure --enable-stlink && make install && \
+    cp contrib/60-openocd.rules /etc/udev/rules.d/ && \
+    cd ../ && rm -rf openocd
 
 # install qemu from xilinx
 # qemu xilinx doesn't support 32-bit architecture, skip armv7 architectures


### PR DESCRIPTION
JIRA: PD-234

 - Even if libusb-1.0-0 is installed it's needed to install it by apt-get after updating repositories, then the following error will disappear:
  ![Screenshot from 2022-12-01 16-33-42](https://user-images.githubusercontent.com/77304431/207896062-e25a68f9-efbb-4138-9276-c15d551d494b.png)

 - tclsh needed to avoid the following error (happened when building arm image on amd host) - if tclsh is installed those instructions are not executed.
  ![Screenshot from 2022-12-02 12-48-21](https://user-images.githubusercontent.com/77304431/207894785-cce1d80d-41c2-4715-81a4-fd2807a852d4.png)
  
  This is skipped when tclsh is installed:
  `No installed jimsh or tclsh, building local bootstrap jimsh0`

 - Tested openocd working for both arm and amd64 architectures (by flashing nucleo board and starting gdb server)
    - openocd -f interface/stlink.cfg \
-f target/stm32l4x.cfg -c "reset_config srst_only srst_nogate connect_assert_srst" \
-c "program _boot/armv7m4-stm32l4x6-nucleo/phoenix.disk 0x08000000 verify reset exit"

   - openocd -f interface/stlink.cfg -f target/stm32l4x.cfg -c "reset_config srst_only srst_nogate connect_assert_srst"  -c"init;reset"