### PR TITLE
add tini to amd64 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+* devel: add tini (init system)
+
 ## 20230920 (latest)
 
 * **GCC version: 9.5.0**

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
         libusb-1.0 \
         tclsh \
         ninja-build \
+        tini \
     && rm -rf /var/lib/apt/lists/* \
     && c_rehash # needed for armv7 CA certs to work
 


### PR DESCRIPTION
exit() test was failing during Ci on host-generic-pc due to lack of init system in docker container. This can be fixed by adding tini (lightway init system) to host docker image. I tested it on local devel image.