### PR TITLE
devel, gh-runner: add support for stm32n6 in openocd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+* devel, gh-runner: add support for stm32n6 in openocd
+
 ## 20260212 (latest)
 
 * build: install python3-pycryptodome

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -33,9 +33,11 @@ RUN apt-get update && \
     && c_rehash # needed for armv7 CA certs to work
 
 # install openocd in 0.12 version
+# cherry-pick commit adding support for stm32n6
 RUN mkdir -p /etc/udev/rules.d && \
     git clone https://github.com/openocd-org/openocd.git --branch v0.12.0 && \
     cd openocd && \
+    git cherry-pick --no-commit 7d688bc500e011d1c39c17e2a8e402c8f1bcd58e && \
     ./bootstrap && \
     ./configure --enable-stlink && make install && \
     cp contrib/60-openocd.rules /etc/udev/rules.d/ && \

--- a/gh-runner/Dockerfile
+++ b/gh-runner/Dockerfile
@@ -27,9 +27,11 @@ RUN apt-get update && \
 
 
 # install openocd in 0.12 version
+# cherry-pick commit adding support for stm32n6
 RUN mkdir -p /etc/udev/rules.d && \
     git clone https://github.com/openocd-org/openocd.git --branch v0.12.0 && \
     cd openocd && \
+    git cherry-pick --no-commit 7d688bc500e011d1c39c17e2a8e402c8f1bcd58e && \
     ./bootstrap && \
     ./configure --enable-stlink && make install -j 9 && \
     cp contrib/60-openocd.rules /etc/udev/rules.d/ && \


### PR DESCRIPTION
Tested by running tests on armv8m55-stm32-nucleo target from devel container.

JIRA: CI-598