### PR TITLE
devel: delete python3-pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+* devel: delete python3-pip
+
 ## 20260312 (latest)
 
 * build: install python3-{packaging,resolvelib,pyparsing,rich}, jq

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
         ca-certificates \
         python3-dev \
         python3-venv \
-        python3-pip \
         opensbi \
         qemu-system-i386 \
         qemu-system-misc \


### PR DESCRIPTION
Due to the addition of python3-pip in the build image, it is no longer required in the devel image, as the devel image is based on the build image.

YT: CI-664