### PR TITLE
move python3-pip from devel to build image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## NEXT VERSION
 
+* build: install littlefs-python
+* move python3-pip from devel to build image
+
 ## 20260312 (latest)
 
 * build: install python3-{packaging,resolvelib,pyparsing,rich}, jq

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
         ca-certificates \
         python3-dev \
         python3-venv \
-        python3-pip \
         opensbi \
         qemu-system-i386 \
         qemu-system-misc \


### PR DESCRIPTION
Due to the addition of python3-pip in the build image, it is no longer required in the devel image, as the devel image is based on the build image.

YT: CI-664

<!-- All boxes must be checked before marking the PR as ready for review. -->

## Checklist

- [x] This is not a pre-release PR (releases only on the master branch)
- [x] `CHANGELOG.md` updated
- [x] All affected images built locally for all supported architectures
- [x] Changes were tested on all supported target architectures: running test runner in a devel image for ia32-generic-qemu
<!-- describe shortly what has been tested, e.g. running test runner in a devel image for all affected target architectures (when the qemu version is bumped) -->
